### PR TITLE
Add hack to allow rebooting from greeter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-lightdm-config (1.13.1) unstable; urgency=low
+
+  * Add a hack to allow users to reboot the workstation from the greeter,
+    on debathena-cluster only, and only if the user has been idle for long
+    enough.
+
+ -- Jonathan Reed <jdreed@mit.edu>  Tue, 08 Jul 2014 17:16:21 -0400
+
 debathena-lightdm-config (1.13) unstable; urgency=low
 
   * Make greeter play nice with Switch User feature in Trusty and other

--- a/debian/debathena-lightdm-greeter
+++ b/debian/debathena-lightdm-greeter
@@ -585,6 +585,9 @@ class DebathenaGreeter:
 
 
     def find_logged_in_user_name(self):
+        # Ensure we only do this if c-l-c is installed
+        if not os.path.exists("/usr/share/debathena-cluster-login-config/screensaver_logout.sh"):
+            return None
         bus = dbus.SystemBus()
         try:
             manager = dbus.Interface(bus.get_object(LD_NAME, LD_MANAGER_PATH),
@@ -604,15 +607,26 @@ class DebathenaGreeter:
                                             'org.freedesktop.DBus.Properties')
             properties = obj_properties.GetAll(LD_SESSION_IFACE)
             if properties['Type'] == 'x11' and properties['Class'] == 'user':
-                msgTxt = "This workstation is currently locked by {0}@mit.edu."
-                msgTxt += "\nYou must enter your password to unlock it."
-                dlg = Gtk.MessageDialog(self.winLogin,
-                                        Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                                        Gtk.MessageType.INFO,
-                                        Gtk.ButtonsType.OK,
-                                        msgTxt.format(properties['Name']))
-                dlg.run()
-                dlg.destroy()
+                dlg = self.builder.get_object("dlgLocked")
+                lbl = self.builder.get_object("lblLocked")
+                login_at = int(properties['Timestamp']) / 1000000
+                idle = int(time.time()) - login_at
+                self.builder.get_object("lblLogout").set_visible(idle >= 1200)
+                self.builder.get_object("btnReboot").set_visible(idle >= 1200)
+                lbl.set_text(lbl.get_text().replace('@LOCKTIME@',
+                                                    time.ctime(login_at)))
+                lbl.set_text(
+                    lbl.get_text().replace('@USERNAME@',
+                                           '{0}@mit.edu'.format(
+                            properties['Name'])))
+
+                rv = dlg.run()
+                dlg.hide()
+                if rv == 42:
+                    try:
+                        subprocess.check_call(['sudo', 'reboot'])
+                    except subprocess.CalledProcessError as e:
+                        self.errDialog("Could not reboot workstation.  Try pressing power switch.")
                 return properties['Name']
         return None
 

--- a/debian/debathena-lightdm-greeter.ui
+++ b/debian/debathena-lightdm-greeter.ui
@@ -1,6 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
+  <object class="GtkDialog" id="dlgLocked">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Locked</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="type_hint">dialog</property>
+    <property name="transient_for">winLogin</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btnReboot">
+                <property name="label" translatable="yes">Reboot</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">Unlock</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">10</property>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Workstation Locked</property>
+                <attributes>
+                  <attribute name="font-desc" value="Sans Bold 12"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="lblLocked">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="label" translatable="yes">This workstation has been locked since
+@LOCKTIME@
+and can only be unlocked by
+@USERNAME@.</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="lblLogout">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="label" translatable="yes">Because this workstation has been idle
+for more than 20 minutes, you may force
+logout the user and reboot this workstation
+by clicking "Reboot" below.</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="42">btnReboot</action-widget>
+      <action-widget response="0">button2</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkImage" id="imgAccess">
     <property name="visible">True</property>
     <property name="can_focus">False</property>


### PR DESCRIPTION
Add a hack to allow rebooting from the greeter, if c-l-c is
installed.  This should be removed as soon as Unity decides to
ship a configurable and functional screen-locker
