### PR TITLE
Make postinst install on systemd systems by ignoring errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+debathena-lightdm-config (1.13.3) unstable; urgency=medium
+
+  * Fix the postinst to install on a systemd system by ignoring errors (Trac:
+    #1554)
+
+ -- Lizhou Sha <slz@mit.edu>  Sat, 06 May 2017 23:21:39 -0400
+
 debathena-lightdm-config (1.13.2) unstable; urgency=low
 
   * Tweak the kiosk launching command to use the normal session startup

--- a/debian/debathena-lightdm-config.postinst
+++ b/debian/debathena-lightdm-config.postinst
@@ -39,8 +39,14 @@ case "$1" in
 	# Deal with the fact that symlinks don't work in /etc/init 
 	# If we managed to confuse upstart such that we don't exist,
 	# force a reload:
-	if ! status lightdm >/dev/null 2>&1; then
+	# Also check that initctl can connect to upstart system bus, or indeed, exist at all
+	if initctl version 2>/dev/null && ! status lightdm >/dev/null 2>&1; then
 	    # I hope this doesn't break the world.
+	    # Update: This does break the world on xenial, which uses upstart, but
+	    # only in the user session, so initctl doesn't see it running in this
+	    # script. Temporary hack in the if statement above to let the package
+	    # install, with intent to deprecate once the last vestiges of upstart
+	    # has been purged from our collective memory.
 	    initctl reload-configuration
 	fi
 	if pgrep -u lightdm -f debathena-lightdm-greeter >/dev/null 2>&1; then


### PR DESCRIPTION
This has been tested to "work" on xenial and zesty. We pray that it also "works" on yakkety.