### PR TITLE
Port to Python 3, fix deprecation warnings

### DIFF
--- a/debian/debathena-lightdm-greeter
+++ b/debian/debathena-lightdm-greeter
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 #
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('LightDM', '1')
 from gi.repository import GObject
 from gi.repository import GLib
 from gi.repository import Gio
@@ -17,7 +20,7 @@ import pwd
 import time
 import os.path
 from optparse import OptionParser
-import ConfigParser
+import configparser
 import io
 LD_NAME = 'org.freedesktop.login1'
 LD_MANAGER_PATH = '/org/freedesktop/login1'
@@ -49,9 +52,9 @@ class DebathenaGreeter:
     def _debug(self, *args):
         if self.debugMode:
             if type(args[0]) is str and len(args) > 1:
-                print >> sys.stderr, "D: " + args[0], args[1:]
+                print("D: " + args[0], args[1:], file=sys.stderr)
             else:
-                print >> sys.stderr, "D: ", args[0]
+                print("D: ", args[0], file=sys.stderr)
 
     def __init__(self, options, config):
         self.debugMode = options.debug
@@ -102,7 +105,7 @@ class DebathenaGreeter:
                              self.cbAuthenticationComplete)
         self.greeter.connect("show-message", self.cbShowMessage)
         self.greeter.connect("show-prompt", self.cbShowPrompt)
-        self.greeter.connect_sync()
+        self.greeter.connect_to_daemon_sync()
 
         # Gtk signal handlers
         handlers = {
@@ -130,9 +133,9 @@ class DebathenaGreeter:
         self.beingCancelled=False
  
         # Save the screen size for various window operations
-        defaultScreen = Gdk.Screen.get_default()
+        defaultScreen = Gdk.Display.get_default()
         # Kids these days have too many monitors
-        self.monitorGeometry = defaultScreen.get_monitor_geometry(defaultScreen.get_primary_monitor())
+        self.monitorGeometry = defaultScreen.get_primary_monitor().get_geometry()
         # Don't use this for window centering calculations
         self.screenSize = (self.monitorGeometry.x + self.monitorGeometry.width,
                            self.monitorGeometry.y + self.monitorGeometry.height)
@@ -142,8 +145,8 @@ class DebathenaGreeter:
         self.builder = Gtk.Builder()
         try: 
             self.builder.add_from_file(options.ui_file)
-        except GLib.GError, e:
-            print >> sys.stderr, "FATAL: Unable to load UI: ", e
+        except GLib.GError as e:
+            print("FATAL: Unable to load UI: ", e, file=sys.stderr)
             sys.exit(-1)
 
         # This is just ridiculous.  Due to a GtkBuilder bug, it scribbles over
@@ -199,8 +202,8 @@ class DebathenaGreeter:
         self.winLogin.show()
         self.initBackgroundWindow()
         self.initBrandingWindow()
-        self.afsMonitor = Gio.File.new_for_path("/afs/athena").monitor_directory(Gio.FileMonitorFlags.WATCH_MOUNTS, None)
-        self.afsAvailable = os.path.isdir("/afs/athena")
+        self.afsMonitor = Gio.File.new_for_path("/afs/athena.mit.edu").monitor_directory(Gio.FileMonitorFlags.WATCH_MOUNTS, None)
+        self.afsAvailable = os.path.isdir("/afs/athena.mit.edu")
         self.afsMonitor.connect("changed", self.afsStatusChanged)
         self.initMotdWindow()
         # Connect Gtk+ signal handlers
@@ -223,6 +226,7 @@ class DebathenaGreeter:
 
         if not os.path.exists(KIOSK_LAUNCH_CMD):
             self.builder.get_object("mnuBrowse").hide()
+
         # Setup the login window for first login
         self.resetLoginWindow()
 
@@ -235,11 +239,11 @@ class DebathenaGreeter:
                 if codename and os.path.exists(self.motdFilename + "." + codename.strip()):
                     self.motdFilename += "." + codename.strip()
             except OSError:
-                print >>sys.stderr, "Couldn't get codename to append to motd_filename.  Oh well..."
+                print("Couldn't get codename to append to motd_filename.  Oh well...", file=sys.stderr)
         try:
             motdFile = open(self.motdFilename, "r")
-        except IOError, e:
-            print >>sys.stderr, "Can't open MOTD file %s: %s" % (self.motdFilename, str(e))
+        except IOError as e:
+            print("Can't open MOTD file %s: %s" % (self.motdFilename, str(e)), file=sys.stderr)
         motdTxt = ''
         # Avoid huge files messing up the greeter
         # At most 10 lines of 80 characters per line
@@ -272,8 +276,8 @@ class DebathenaGreeter:
         try:
             bg_pixbuf = GdkPixbuf.Pixbuf.new_from_file(self.backgroundImageFile)
             bg_scaled = bg_pixbuf.scale_simple(self.screenSize[0], self.screenSize[1], GdkPixbuf.InterpType.BILINEAR)
-        except GLib.GError, e:
-            print >> sys.stderr, "Glib Error while loading background image:", e
+        except GLib.GError as e:
+            print("Glib Error while loading background image:", e, file=sys.stderr)
             # Just a plain black background
             bg_scaled = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8, self.screenSize[0], self.screenSize[1])
         self.imgBg.set_from_pixbuf(bg_scaled)
@@ -335,8 +339,8 @@ class DebathenaGreeter:
             actions[widget.get_name()]()
         except KeyError:
             # "won't" happen
-            print >>sys.stderr, "ERR: No action for widget name: "+ widget.get_name()
-        except GLib.GError, e:
+            print("ERR: No action for widget name: "+ widget.get_name(), file=sys.stderr)
+        except GLib.GError as e:
             # It's possible we should look at the error text to see if
             # it's ConsoleKit that's whining?  Because you get a
             # (valid) error from UPower if you try to suspend when
@@ -357,10 +361,10 @@ class DebathenaGreeter:
                 self.onboardProc = subprocess.Popen([PICKBOARD_CMD, "--xid"],
                                                 stdout=subprocess.PIPE)
                 xid = int(self.onboardProc.stdout.readline())
-            except OSError, e:
-                print >>sys.stderr, "Failed to spawn /usr/bin/onboard", str(e)
+            except OSError as e:
+                print("Failed to spawn /usr/bin/onboard", str(e), file=sys.stderr)
             except ValueError:
-                print >>sys.stderr, "onboard didn't return an integer xid (shouldn't happen)"
+                print("onboard didn't return an integer xid (shouldn't happen)", file=sys.stderr)
                 self.onboardProc.kill()
 
             if self.onboardProc is None or xid is None:
@@ -474,7 +478,7 @@ class DebathenaGreeter:
             self._debug("User has selected '%s' session" % (session_name))
             if not greeter.start_session_sync(session_name):
                 self._debug("Failed to start session")
-                print >> sys.stderr, "Failed to start session"
+                print("Failed to start session", file=sys.stderr)
         elif not self.beingCancelled:
             self._debug("Authentication failed.")
             self.displayMessage("Authentication failed, please try again")
@@ -600,7 +604,7 @@ class DebathenaGreeter:
                                      LD_MANAGER_IFACE)
         except dbus.exceptions.DBusException as e:
             if e.get_dbus_name() != "org.freedesktop.DBus.Error.ServiceUnknown":
-                print >>sys.stderr, "Unexpected DBus Exception", e
+                print("Unexpected DBus Exception", e, file=sys.stderr)
             return None
         sessions = manager.ListSessions()
         target_sessions = {}
@@ -681,8 +685,8 @@ class DebathenaGreeter:
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file(img)
                 self.logo_pixbufs.append(pixbuf.scale_simple(int(pixbuf.get_width() * logoScale), int(pixbuf.get_height() * logoScale), GdkPixbuf.InterpType.BILINEAR))
                 num_pixbufs += 1
-            except GLib.GError, e:
-                print >> sys.stderr, "Glib Error:", e
+            except GLib.GError as e:
+                print("Glib Error:", e, file=sys.stderr)
                 return False
         # Eyes come open.
         for pixbuf in self.logo_pixbufs[::-1]:
@@ -730,17 +734,17 @@ if __name__ == '__main__':
     parser.add_option("--cfg", action="store", type="string",
                       default=CONFIG_FILE, dest="config_file")
     (options, args) = parser.parse_args()
-    config = ConfigParser.RawConfigParser(CONFIG_DEFAULTS)
+    config = configparser.RawConfigParser(CONFIG_DEFAULTS)
     # Hack to create a 'Greeter' section so that we can just use that
     # in any calls
-    config.readfp(io.BytesIO("[Greeter]\n"))
+    config.read_file(io.StringIO("[Greeter]\n"))
     config.read(options.config_file)
     Gtk.init(None);
-    main_loop = GObject.MainLoop ()
+    main_loop = GLib.MainLoop ()
     dagreeter = DebathenaGreeter(options, config)
     # Add a timeout for the owl animation
-    GObject.timeout_add(50, dagreeter.update_owl)
+    GLib.timeout_add(50, dagreeter.update_owl)
     # Add a timeout for the clock in the panel
-    GObject.timeout_add(30, dagreeter.updateTime)
+    GLib.timeout_add(30, dagreeter.updateTime)
 
     main_loop.run ()


### PR DESCRIPTION
This patch is from the new SIPB Nixathena project.

The only nontrivial thing I changed is to make the greeter wait for `/afs/athena.mit.edu` instead of `/afs/athena`.